### PR TITLE
Add option to control ansible_managed in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ None.
 * ``etckeeper_avoid_daily_autocommits``: Configure etckeeper to set AVOID_DAILY_AUTOCOMMITS=1 (default: ``false``)
 * ``etckeeper_avoid_commit_before_install``: Configure etckeeper to set AVOID_COMMIT_BEFORE_INSTALL=1 (default: ``false``)
 
+* ``etckeeper_with_cow``: Change wether the configuration files 'Managed by ansible' warning should be said by a cow or not (defaut: ``true``)
 
 # Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,3 +8,6 @@ etckeeper_darcs_commit_options: ""
 
 etckeeper_avoid_daily_autocommits: false
 etckeeper_avoid_commit_before_install: false
+
+etckeeper_with_cow: true
+

--- a/templates/etckeeper.j2
+++ b/templates/etckeeper.j2
@@ -1,3 +1,4 @@
+{% if etckeeper_with_cow %}
 #   ____________________ 
 #  < Managed by Ansible >
 #   -------------------- 
@@ -7,6 +8,9 @@
 #                  ||----w |
 #                  ||     ||
 #
+{% else %}
+# {{ ansible_managed }}
+{% endif %}
 
 VCS="{{ etckeeper_vcs }}"
 


### PR DESCRIPTION
Most roles simply use # {{ ansible_managed }} as the top line of their
configuration file so in many cases thats what people will be looking for (ie,
me). For consistency with other roles/templates this option allows swapping
between the default cow saying 'Managed by Ansible' and '# {{ ansible_managed
}}'
