### PR TITLE
Add comments and missing option to template

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ None.
 * ``etckeeper_hg_commit_options``: Configure Mercurial commit options for etckeeper (default: "")
 * ``etckeeper_bzr_commit_options``: Configure Bazaar commit options for etckeeper (default: "")
 * ``etckeeper_darcs_commit_options``: Configure Darcs commit options for etckeeper (default: "")
+* ``etckeeper_avoid_special_file_warning``: Configure etckeeper to set AVOID_SPECIAL_FILE_WARNING=1 (default: ``false``)
 * ``etckeeper_avoid_daily_autocommits``: Configure etckeeper to set AVOID_DAILY_AUTOCOMMITS=1 (default: ``false``)
 * ``etckeeper_avoid_commit_before_install``: Configure etckeeper to set AVOID_COMMIT_BEFORE_INSTALL=1 (default: ``false``)
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,5 +6,6 @@ etckeeper_hg_commit_options: ""
 etckeeper_bzr_commit_options: ""
 etckeeper_darcs_commit_options: ""
 
+etckeeper_avoid_special_file_warning: false
 etckeeper_avoid_daily_autocommits: false
 etckeeper_avoid_commit_before_install: false

--- a/templates/etckeeper.j2
+++ b/templates/etckeeper.j2
@@ -8,27 +8,52 @@
 #                  ||     ||
 #
 
+# The VCS to use.
 VCS="{{ etckeeper_vcs }}"
 
 {% if etckeeper_git_commit_options != '' %}
+# Options passed to git commit when run by etckeeper.
 GIT_COMMIT_OPTIONS="{{ etckeeper_git_commit_options }}"
 {% endif %}
+
 {% if etckeeper_hg_commit_options != '' %}
+# Options passed to hg commit when run by etckeeper.
 HG_COMMIT_OPTIONS="{{ etckeeper_hg_commit_options }}"
 {% endif %}
+
 {% if etckeeper_bzr_commit_options != '' %}
+# Options passed to bzr commit when run by etckeeper.
 BZR_COMMIT_OPTIONS="{{ etckeeper_bzr_commit_options }}"
 {% endif -%}
+
 {% if etckeeper_darcs_commit_options != '' %}
+# Options passed to darcs record when run by etckeeper.
 DARCS_COMMIT_OPTIONS="{{ etckeeper_darcs_commit_options }}"
 {% endif -%}
 
 {% if etckeeper_avoid_daily_autocommits %}
+# Uncomment to avoid etckeeper committing existing changes
+# to /etc automatically once per day.
 AVOID_DAILY_AUTOCOMMITS=1
 {% endif %}
+
+{% if etckeeper_avoid_special_file_warning %}
+# Uncomment the following to avoid special file warning
+# (the option is enabled automatically by cronjob regardless).
+AVOID_SPECIAL_FILE_WARNING=1
+{% endif %}
+
 {% if etckeeper_avoid_commit_before_install %}
+# Uncomment to avoid etckeeper committing existing changes to 
+# /etc before installation. It will cancel the installation,
+# so you can commit the changes by hand.
 AVOID_COMMIT_BEFORE_INSTALL=1
 {% endif %}
 
+# The high-level package manager that's being used.
+# (apt, pacman-g2, yum etc)
 HIGHLEVEL_PACKAGE_MANAGER={{ etckeeper_highlevel_package_manager }}
+
+# The low-level package manager that's being used.
+# (dpkg, rpm, pacman-g2, etc)
 LOWLEVEL_PACKAGE_MANAGER={{ etckeeper_lowlevel_package_manager }}


### PR DESCRIPTION
When working on a system under presure its good to be able to have some context
to the options in the file. In this specific case the options are fairly self
explanitory but having the comment helps explain what they are meant to do.

This change adds the comments with the relevant option so ony those related to
(eg) git show when (eg) etckeeper_git_commit_options is set.

This also adds an option for etckeeper_avoid_special_file_warning which could
be a separate branch but seemed unintrusive enough to bundle in with this set
of changes. Its only relevant for users running the command manually (as I am
at the moment) so shouldn't affect the role very much.
