### PR TITLE
Enforce stronger permissions on /etc/.git.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,3 +19,6 @@ etckeeper_epel_mirrorurl: 'https://mirrors.fedoraproject.org/metalink'
 etckeeper_epel_enable_debug: false
 etckeeper_epel_enable_source: false
 
+## Sets the group for /etc/.git.
+etckeeper_repository_group: root
+etckeeper_repository_permissions_mode: "0750"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,22 +27,31 @@
   tags: etckeeper
   sudo: yes
   file:
-    state=directory
-    mode=0755
-    owner=root
-    group=root
-    dest=/etc/etckeeper
+    state: directory
+    mode: 0755
+    owner: root
+    group: root
+    dest: /etc/etckeeper
 
 - name: Install etckeeper configuration
   tags: etckeeper
   sudo: yes
   template:
-    src=etckeeper.j2
-    dest=/etc/etckeeper/etckeeper.conf
-    mode=0644
-    owner=root
-    group=root
+    src: etckeeper.j2
+    dest: /etc/etckeeper/etckeeper.conf
+    mode: 0644
+    owner: root
+    group: root
 
+- name: Set repository permissions
+  tags: etckeeper
+  sudo: yes
+  file:
+    state: directory
+    path: /etc/.git
+    mode: "{{ etckeeper_repository_permissions_mode }}"
+    owner: root
+    group: "{{ etckeeper_repository_group }}"
 
 - include: Debian.yml
   when: ansible_os_family == 'Debian'

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -5,6 +5,7 @@ etckeeper_supported_platforms:
 
 etckeeper_supported_vcs:
   - git
-  - mercurial
-  - bzr
-  - darcs
+  ## FIXME: Set repository permissions
+  # - mercurial
+  # - bzr
+  # - darcs


### PR DESCRIPTION
* Not sure what the default is intended to be but on my systems it is
  something like 755 which is sucks. Every normal user can clone /etc.
  This might be only on my systems not sure?
* This commit disables support for VCSs other than git. I don’t need
  anything except git …