### PR TITLE
Enforce stronger permissions on VCS repo (currently supported git).

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,3 +23,8 @@ etckeeper_gitignore:
   - 'tor/keys/'
 etckeeper_gitignore_group: []
 etckeeper_gitignore_host: []
+
+# Enforce permissions for the VCS repository.
+etckeeper_repository_user: root
+etckeeper_repository_group: root
+etckeeper_repository_permissions_mode: '0750'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -68,3 +68,17 @@
     dest='/etc/.gitignore'
     line="{{ item }}"
     insertbefore='BOF'
+
+- name: Set repository permissions
+  tags: etckeeper
+  become: true
+  file:
+    state: directory
+    path: '{{ item.path }}'
+    mode: '{{ etckeeper_repository_permissions_mode }}'
+    owner: '{{ etckeeper_repository_user }}'
+    group: '{{ etckeeper_repository_group }}'
+  when: etckeeper_vcs == item.vcs|default('git')
+  with_items:
+    - vcs: git
+      path: /etc/.git


### PR DESCRIPTION
* Related to https://github.com/silpion/ansible-etckeeper/pull/7.

This time less invasive :smile:

PR was made against master, closing …