### PR TITLE
Change dependency from silpion to groover

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,6 @@
 ---
 dependencies:
-  - { role: silpion.util }
+  - { role: groover.util }
 
 galaxy_info:
   author: Mark Kusch


### PR DESCRIPTION
Although the documentation suggests it will work, installing this package currently fails due to its dependency being mis-named.

You can see here that silpion has no packages https://galaxy.ansible.com/authors/?author=silpion
And that groover has a util https://galaxy.ansible.com/groover/

There are other places this change needs to be made, but this is most important as it is a dependency field.